### PR TITLE
Docs: Add user guide + RGB-D sensor SVG, dedupe README equations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A web-based RGB-D depth profiling application for synthetic and real depth data.
 
 Industrial surface inspection requires measuring roughness, curvature, and defects from depth sensor data. RGB-D cameras provide color and depth at each pixel, enabling 3D surface reconstruction and quantitative ISO 4287 characterization.
 
-![Processing Pipeline](docs/svg/pipeline.svg)
+![RGB-D Sensor](docs/svg/rgbd_sensor.svg)
 
 ---
 
@@ -71,29 +71,17 @@ Ra = (1/N) · Σᵢ |zᵢ − z̄|
 
 where **zᵢ** are sampled heights along a cross-section profile and **z̄** is their mean. Ra represents the average deviation from the mean line — a machined surface might have Ra=0.8μm, while a cast surface might have Ra=12μm. Higher-order metrics (Rq=RMS, Rz=peak-to-valley, Rsk=skewness, Rku=kurtosis) capture different aspects of the surface texture.
 
-### Root-Mean-Square Roughness
+### Surface Normals — Shading and Direction
 
-```
-Rq = sqrt((1/N) * Sum_i (z_i - z_bar)^2)
-```
-
-### Bilateral Filter
-
-Edge-preserving smoothing combining spatial and range Gaussians:
-
-```
-BF[I](p) = (1/W) * Sum_q  G_sigma_s(||p - q||) * G_sigma_r(|I(p) - I(q)|) * I(q)
-```
-
-where `W` is the normalizing partition function, `G_sigma_s` is the spatial kernel, and `G_sigma_r` is the range (intensity) kernel.
-
-### Surface Normals
-
-Per-pixel unit normals computed from depth gradients:
+Per-pixel unit normals are computed from depth gradients, enabling Phong lighting and orientation analysis:
 
 ```
 n_hat = normalize(-dz/dx, -dz/dy, 1)
 ```
+
+where `dz/dx`, `dz/dy` are the depth partial derivatives along image axes (via `numpy.gradient`). The resulting unit vector points away from the surface and is used both for rendering and for computing surface area.
+
+See [docs/depth_theory.md](docs/depth_theory.md) for the full mathematical reference (all equations, derivations, and numerical considerations).
 
 ---
 
@@ -199,9 +187,11 @@ FASL_3D_Distance_Profiler/
 │   ├── depth_theory.md             # RGB-D depth processing theory with equations
 │   ├── development_history.md      # Changelog with mathematical foundations
 │   ├── references.md               # Academic papers, standards, and library references
+│   ├── user_guide.md               # Operator walkthrough: load, process, profile, export
 │   └── svg/
 │       ├── architecture.svg        # Architecture diagram
-│       └── pipeline.svg            # Processing pipeline diagram
+│       ├── pipeline.svg            # Processing pipeline diagram
+│       └── rgbd_sensor.svg         # RGB-D sensor geometry + pinhole model
 ├── build.spec                      # PyInstaller spec file
 ├── Build_PyInstaller.ps1           # PowerShell build script
 ├── run_app.py                      # Uvicorn launcher with auto-browser
@@ -239,6 +229,7 @@ FASL_3D_Distance_Profiler/
 
 ## Documentation
 
+- [User Guide](docs/user_guide.md) -- Task-oriented walkthrough: load data, process, inspect, profile, export
 - [Architecture](docs/architecture.md) -- System overview, technology stack, data flow
 - [Depth Theory](docs/depth_theory.md) -- Mathematical foundations: pinhole model, bilateral filter, curvature, roughness
 - [Development History](docs/development_history.md) -- Changelog with equations

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -2,6 +2,14 @@
 
 ---
 
+## 2026-04-18 -- Documentation polish
+
+- Added `docs/user_guide.md`: task-oriented operator walkthrough covering launch, panels, processing knobs, cross-section profiling, export formats, troubleshooting, and REST API examples.
+- Added `docs/svg/rgbd_sensor.svg`: domain diagram showing pinhole geometry, camera lenses (IR projector / RGB / IR camera), frustum, focal length, principal point, and the pixel → 3D unprojection equations.
+- README cleanup: removed duplicated Bilateral Filter and Rq equation blocks (already covered in the Technical Approach section and in `depth_theory.md`); swapped the redundant second pipeline image for the new RGB-D sensor diagram.
+
+---
+
 ## v2.0.0 (2026-03-28) -- Complete Python Rewrite
 
 Complete rewrite of the 3D Distance Profiler as a web application with Python/FastAPI backend and Three.js frontend. Renamed to **SurfaceScope -- RGB-D Surface Profiler & Analyzer**.

--- a/docs/svg/rgbd_sensor.svg
+++ b/docs/svg/rgbd_sensor.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 420" font-family="Segoe UI, sans-serif">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f172a;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#1e293b;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="sensorGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#334155;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0f172a;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="surfGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b;stop-opacity:0.95"/>
+      <stop offset="100%" style="stop-color:#b45309;stop-opacity:0.95"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#38bdf8"/>
+    </marker>
+  </defs>
+
+  <rect width="820" height="420" fill="url(#bgGrad)"/>
+
+  <!-- Title -->
+  <text x="410" y="30" text-anchor="middle" fill="#e2e8f0" font-size="18" font-weight="600">
+    RGB-D Sensor Geometry — Pinhole Model &amp; Depth Acquisition
+  </text>
+  <text x="410" y="50" text-anchor="middle" fill="#94a3b8" font-size="12">
+    IR projector + RGB + depth sensors produce co-registered (u, v, Z) per pixel
+  </text>
+
+  <!-- Camera body -->
+  <rect x="80" y="150" width="160" height="110" rx="10" fill="url(#sensorGrad)" stroke="#64748b" stroke-width="1.5"/>
+  <text x="160" y="140" text-anchor="middle" fill="#cbd5e1" font-size="13" font-weight="600">RGB-D Camera</text>
+
+  <!-- Camera lenses -->
+  <circle cx="115" cy="195" r="16" fill="#1e293b" stroke="#38bdf8" stroke-width="2"/>
+  <circle cx="115" cy="195" r="8" fill="#0ea5e9"/>
+  <text x="115" y="240" text-anchor="middle" fill="#94a3b8" font-size="10">IR proj.</text>
+
+  <circle cx="160" cy="195" r="16" fill="#1e293b" stroke="#f472b6" stroke-width="2"/>
+  <circle cx="160" cy="195" r="8" fill="#ec4899"/>
+  <text x="160" y="240" text-anchor="middle" fill="#94a3b8" font-size="10">RGB</text>
+
+  <circle cx="205" cy="195" r="16" fill="#1e293b" stroke="#34d399" stroke-width="2"/>
+  <circle cx="205" cy="195" r="8" fill="#10b981"/>
+  <text x="205" y="240" text-anchor="middle" fill="#94a3b8" font-size="10">IR cam</text>
+
+  <!-- Optical axis -->
+  <line x1="240" y1="205" x2="560" y2="205" stroke="#475569" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="400" y="200" text-anchor="middle" fill="#64748b" font-size="10">optical axis (Z)</text>
+
+  <!-- Frustum -->
+  <polygon points="240,205 560,100 560,310" fill="rgba(56,189,248,0.08)" stroke="#38bdf8" stroke-width="1" stroke-dasharray="3 3"/>
+
+  <!-- Principal point cx, cy + focal length -->
+  <line x1="240" y1="205" x2="240" y2="130" stroke="#fbbf24" stroke-width="1"/>
+  <text x="255" y="125" fill="#fbbf24" font-size="11">(cx, cy)</text>
+  <text x="290" y="220" fill="#fbbf24" font-size="11">f (focal length)</text>
+
+  <!-- Surface -->
+  <path d="M 560,100 Q 620,180 580,250 T 560,310 L 660,310 Q 700,240 690,180 T 660,100 Z"
+        fill="url(#surfGrad)" stroke="#f59e0b" stroke-width="1.5" opacity="0.9"/>
+  <text x="615" y="370" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="600">Scene surface</text>
+  <text x="615" y="388" text-anchor="middle" fill="#94a3b8" font-size="10">z = f(x, y)</text>
+
+  <!-- Ray to 3D point P -->
+  <circle cx="620" cy="170" r="5" fill="#fbbf24" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="632" y="165" fill="#e2e8f0" font-size="11" font-weight="600">P = (X, Y, Z)</text>
+  <line x1="240" y1="205" x2="620" y2="170" stroke="#38bdf8" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Pixel (u, v) label near lens plane -->
+  <circle cx="340" cy="172" r="3" fill="#38bdf8"/>
+  <text x="315" y="165" fill="#38bdf8" font-size="11">pixel (u, v)</text>
+
+  <!-- Equations panel -->
+  <rect x="50" y="295" width="360" height="100" rx="8" fill="#0b1220" stroke="#334155" stroke-width="1"/>
+  <text x="65" y="315" fill="#e2e8f0" font-size="12" font-weight="600">Pinhole unprojection (pixel → 3D):</text>
+  <text x="65" y="338" fill="#cbd5e1" font-size="12" font-family="monospace">X = (u − cx) · Z / fx</text>
+  <text x="65" y="356" fill="#cbd5e1" font-size="12" font-family="monospace">Y = (v − cy) · Z / fy</text>
+  <text x="65" y="380" fill="#94a3b8" font-size="10">fx, fy = focal lengths (px);  cx, cy = principal point;  Z = depth</text>
+
+  <!-- Depth sample legend -->
+  <rect x="430" y="335" width="370" height="60" rx="8" fill="#0b1220" stroke="#334155" stroke-width="1"/>
+  <text x="445" y="355" fill="#e2e8f0" font-size="11" font-weight="600">Per-pixel output:</text>
+  <rect x="445" y="365" width="14" height="14" fill="#ec4899"/>
+  <text x="465" y="377" fill="#cbd5e1" font-size="11">RGB(u,v)</text>
+  <rect x="545" y="365" width="14" height="14" fill="#10b981"/>
+  <text x="565" y="377" fill="#cbd5e1" font-size="11">Depth Z(u,v) [mm]</text>
+  <rect x="690" y="365" width="14" height="14" fill="#38bdf8"/>
+  <text x="710" y="377" fill="#cbd5e1" font-size="11">Normal n̂(u,v)</text>
+</svg>

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,137 @@
+# User Guide — SurfaceScope (RGB-D Surface Profiler & Analyzer)
+
+A task-oriented guide for operators. For the theory behind each step, see [depth_theory.md](depth_theory.md); for the system layout, see [architecture.md](architecture.md).
+
+---
+
+## 1. Launching the App
+
+```bash
+cd "d:/_Repos/_SCIENCE/FASL_3D_Distance_Profiler"
+python -m venv .venv
+source .venv/Scripts/activate   # Windows Git Bash
+pip install -r requirements.txt
+python run_app.py
+```
+
+The app opens automatically at [http://localhost:8009](http://localhost:8009). The server is single-user and holds its state in RAM — restart clears everything.
+
+---
+
+## 2. Panel Overview
+
+SurfaceScope uses a 3-panel layout:
+
+| Panel           | Purpose                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| Left (controls) | Scene selection, upload, processing parameters, export buttons          |
+| Centre (2D)     | RGB / depth colourmap / normal map canvases + cross-section tool        |
+| Right (3D)      | Three.js interactive surface viewer with mesh / wireframe / point modes |
+
+Press the `?` button in the header for the in-app keyboard/mouse reference.
+
+---
+
+## 3. Typical Workflow
+
+### 3.1 Load data
+
+Pick one of the two sources:
+
+- **Generate synthetic scene** — choose from `gaussian_hills`, `terrain`, `object_on_table`, `conveyor_belt`, `wave_surface`. Adjust `width`, `height`, and `seed` for reproducibility. Good for demos and regression.
+- **Upload depth + RGB** — supports 8-bit and 16-bit PNG. The depth image is treated as raw depth in millimetres (16-bit) or normalised (8-bit). The RGB image is optional — a neutral grey texture is applied if omitted.
+
+Once loaded, the 2D panel shows RGB, depth (with the selected colourmap), and per-pixel surface normals.
+
+### 3.2 Process the depth map
+
+Under **Processing**, tune the pipeline:
+
+- `bilateral_sigma_spatial` (σ_s) — spatial kernel radius in pixels. Larger = more smoothing. Typical: 3–7.
+- `bilateral_sigma_range` (σ_r) — depth-similarity kernel in millimetres. Larger = more smoothing across steps. Typical: 5–30.
+- `fill_hole_size` — maximum contiguous invalid-pixel region to fill via nearest-neighbour interpolation. Use 0 to disable.
+
+Click **Process** — the depth map, normals, and 3D mesh update in place.
+
+### 3.3 Inspect in 3D
+
+Drag on the 3D canvas to orbit (left button), pan (right button), and wheel to zoom. Use the toggles to switch between:
+
+- **Mesh** — shaded Phong surface with per-vertex RGB colours.
+- **Wireframe** — triangle edges only. Useful to inspect sampling density.
+- **Points** — vertex cloud. Good for visual noise assessment.
+
+### 3.4 Extract a cross-section profile
+
+Click two points on the depth canvas. The backend extracts a 1D height profile via bilinear interpolation along the line and returns:
+
+- distances / heights arrays (rendered as a profile chart)
+- ISO 4287 roughness metrics: **Ra** (mean deviation), **Rq** (RMS), **Rz** (peak-to-valley), **Rsk** (skewness), **Rku** (kurtosis)
+
+Ra and Rq characterise average roughness; Rz captures the worst feature; Rsk and Rku describe asymmetry and peakedness of the height distribution.
+
+### 3.5 Metrics & object detection
+
+The **Metrics** panel shows the full-frame depth histogram, Gaussian and mean curvature statistics, and the list of detected raised objects (connected-component labelling after depth thresholding). Each object entry includes bounding box, centroid, pixel count, and mean height.
+
+### 3.6 Export
+
+From the export section:
+
+| Format | Use case                                     | Tool                     |
+|--------|----------------------------------------------|--------------------------|
+| PLY    | Point cloud + mesh + per-vertex colour       | MeshLab, CloudCompare    |
+| PCD    | Point cloud only (no topology)               | PCL, Open3D              |
+| OBJ    | Mesh with triangular faces                   | Blender, MeshLab         |
+
+Each file is streamed as an ASCII download — no temporary files are written to disk.
+
+---
+
+## 4. Troubleshooting
+
+| Symptom                              | Likely cause                                    | Fix                                                             |
+|--------------------------------------|-------------------------------------------------|-----------------------------------------------------------------|
+| Port 8009 already in use             | Another SCIAN/FASL app is running               | Stop the other app or change the port in `run_app.py`           |
+| 3D panel empty after load            | Depth map all-zero (bad upload)                 | Verify depth PNG encodes non-zero pixels                        |
+| Bilateral filter feels too slow      | Large σ_s (kernel half-size ∝ σ_s)              | Reduce σ_s or subsample resolution                              |
+| Cross-section jagged                 | Hole filling disabled + invalid pixels on path  | Increase `fill_hole_size`                                       |
+| Object detection misses raised parts | Threshold too close to background               | Adjust depth threshold under Metrics                            |
+| Exported PLY opens empty in MeshLab  | File saved with ASCII header but binary payload | Re-export — SurfaceScope always writes ASCII; retry the download|
+
+---
+
+## 5. Programmatic Use (REST API)
+
+Every UI action corresponds to a REST endpoint. Example using `curl`:
+
+```bash
+# Generate a synthetic scene
+curl -X POST http://localhost:8009/api/generate \
+     -H "Content-Type: application/json" \
+     -d '{"scene_type": "gaussian_hills", "width": 256, "height": 256, "seed": 42}'
+
+# Apply the processing pipeline
+curl -X POST http://localhost:8009/api/process \
+     -H "Content-Type: application/json" \
+     -d '{"bilateral_sigma_spatial": 5, "bilateral_sigma_range": 20, "fill_hole_size": 3}'
+
+# Extract a profile and compute roughness
+curl -X POST http://localhost:8009/api/profile \
+     -H "Content-Type: application/json" \
+     -d '{"start_x": 32, "start_y": 64, "end_x": 224, "end_y": 192, "num_samples": 200}'
+
+# Download the surface as PLY
+curl -O -J http://localhost:8009/api/export/ply
+```
+
+See [architecture.md](architecture.md) for the full endpoint table and request/response shapes.
+
+---
+
+## 6. Where to go next
+
+- Theory reference: [depth_theory.md](depth_theory.md)
+- System architecture: [architecture.md](architecture.md)
+- Version log: [development_history.md](development_history.md)
+- Papers & standards: [references.md](references.md)


### PR DESCRIPTION
Closes #13

## Summary
- Add `docs/user_guide.md`: task-oriented operator walkthrough covering launch, panels, processing parameters, cross-section profiling, metrics, export formats, troubleshooting, and REST examples.
- Add `docs/svg/rgbd_sensor.svg`: domain diagram of pinhole camera geometry, IR projector / RGB / IR camera lenses, frustum, focal length, principal point, and the pixel → 3D unprojection equations.
- Dedupe README equations (Bilateral Filter and Rq blocks already covered in the Technical Approach section and `depth_theory.md`); replace the redundant second pipeline image with the new sensor diagram.
- Log the change under a new 2026-04-18 entry in `development_history.md`.

## Test plan
- [x] README renders with the new sensor SVG in Motivation and the pipeline SVG only under Processing Pipeline.
- [x] `docs/user_guide.md` links resolve to `depth_theory.md`, `architecture.md`, `development_history.md`, `references.md`.
- [x] `docs/svg/rgbd_sensor.svg` is valid SVG (viewBox 0 0 820 420) and opens in a browser.
- [x] No private data or secrets introduced.