### PR TITLE
Refactor: Extract AppState singleton into app/core/state.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A web-based RGB-D depth profiling application for synthetic and real depth data.
 
 Industrial surface inspection requires measuring roughness, curvature, and defects from depth sensor data. RGB-D cameras provide color and depth at each pixel, enabling 3D surface reconstruction and quantitative ISO 4287 characterization.
 
-![Processing Pipeline](docs/svg/pipeline.svg)
+![RGB-D Sensor](docs/svg/rgbd_sensor.svg)
 
 ---
 
@@ -71,29 +71,17 @@ Ra = (1/N) · Σᵢ |zᵢ − z̄|
 
 where **zᵢ** are sampled heights along a cross-section profile and **z̄** is their mean. Ra represents the average deviation from the mean line — a machined surface might have Ra=0.8μm, while a cast surface might have Ra=12μm. Higher-order metrics (Rq=RMS, Rz=peak-to-valley, Rsk=skewness, Rku=kurtosis) capture different aspects of the surface texture.
 
-### Root-Mean-Square Roughness
+### Surface Normals — Shading and Direction
 
-```
-Rq = sqrt((1/N) * Sum_i (z_i - z_bar)^2)
-```
-
-### Bilateral Filter
-
-Edge-preserving smoothing combining spatial and range Gaussians:
-
-```
-BF[I](p) = (1/W) * Sum_q  G_sigma_s(||p - q||) * G_sigma_r(|I(p) - I(q)|) * I(q)
-```
-
-where `W` is the normalizing partition function, `G_sigma_s` is the spatial kernel, and `G_sigma_r` is the range (intensity) kernel.
-
-### Surface Normals
-
-Per-pixel unit normals computed from depth gradients:
+Per-pixel unit normals are computed from depth gradients, enabling Phong lighting and orientation analysis:
 
 ```
 n_hat = normalize(-dz/dx, -dz/dy, 1)
 ```
+
+where `dz/dx`, `dz/dy` are the depth partial derivatives along image axes (via `numpy.gradient`). The resulting unit vector points away from the surface and is used both for rendering and for computing surface area.
+
+See [docs/depth_theory.md](docs/depth_theory.md) for the full mathematical reference (all equations, derivations, and numerical considerations).
 
 ---
 
@@ -199,9 +187,11 @@ FASL_3D_Distance_Profiler/
 │   ├── depth_theory.md             # RGB-D depth processing theory with equations
 │   ├── development_history.md      # Changelog with mathematical foundations
 │   ├── references.md               # Academic papers, standards, and library references
+│   ├── user_guide.md               # Operator walkthrough: load, process, profile, export
 │   └── svg/
 │       ├── architecture.svg        # Architecture diagram
-│       └── pipeline.svg            # Processing pipeline diagram
+│       ├── pipeline.svg            # Processing pipeline diagram
+│       └── rgbd_sensor.svg         # RGB-D sensor geometry + pinhole model
 ├── build.spec                      # PyInstaller spec file
 ├── Build_PyInstaller.ps1           # PowerShell build script
 ├── run_app.py                      # Uvicorn launcher with auto-browser
@@ -239,6 +229,7 @@ FASL_3D_Distance_Profiler/
 
 ## Documentation
 
+- [User Guide](docs/user_guide.md) -- Task-oriented walkthrough: load data, process, inspect, profile, export
 - [Architecture](docs/architecture.md) -- System overview, technology stack, data flow
 - [Depth Theory](docs/depth_theory.md) -- Mathematical foundations: pinhole model, bilateral filter, curvature, roughness
 - [Development History](docs/development_history.md) -- Changelog with equations

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -6,6 +6,10 @@ RESTful endpoints for generating, uploading, processing, and analysing
 RGB-D depth data.  All heavy computation runs in the backend; the
 frontend receives pre-computed meshes, images, and metrics as JSON.
 
+Application state (current scene) lives in ``app.core.state.AppState``
+and is injected via FastAPI ``Depends(get_app_state)`` so routes remain
+unit-testable and the state can be overridden in tests.
+
 Endpoints
 ---------
 POST /api/generate   - Generate a synthetic RGB-D scene
@@ -20,11 +24,12 @@ import io
 import base64
 import numpy as np
 from typing import Optional, List
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from PIL import Image
 
+from app.core import AppState, get_app_state
 from app.simulation.depth_generator import generate_scene, list_scene_types
 from app.simulation.depth_processing import (
     bilateral_filter_depth,
@@ -49,28 +54,6 @@ from app.simulation.export import export_ply, export_pcd, export_obj_mesh
 from app.simulation.colormap import apply_colormap, COLOURMAP_NAMES
 
 router = APIRouter(prefix="/api", tags=["api"])
-
-
-# ---------------------------------------------------------------------------
-# In-memory state (single-user demo application)
-# ---------------------------------------------------------------------------
-
-class AppState:
-    """Holds the current scene data in memory."""
-    def __init__(self):
-        self.rgb: Optional[np.ndarray] = None          # (H, W, 3) uint8
-        self.depth: Optional[np.ndarray] = None         # (H, W) float32
-        self.normals: Optional[np.ndarray] = None       # (H, W, 3) float32
-        self.processed_depth: Optional[np.ndarray] = None
-        self.scene_type: str = ""
-        self.width: int = 256
-        self.height: int = 256
-
-    def has_data(self) -> bool:
-        return self.depth is not None
-
-
-state = AppState()
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +138,7 @@ async def get_colormaps():
 
 
 @router.post("/generate")
-async def generate(req: GenerateRequest):
+async def generate(req: GenerateRequest, state: AppState = Depends(get_app_state)):
     """Generate a synthetic RGB-D scene and store in application state.
 
     Returns base64-encoded PNG images for RGB, depth colourmap, and
@@ -176,13 +159,14 @@ async def generate(req: GenerateRequest):
     state.width = req.width
     state.height = req.height
 
-    return _build_state_response()
+    return _build_state_response(state)
 
 
 @router.post("/upload")
 async def upload(
     depth_file: UploadFile = File(..., description="Depth map image (16-bit PNG or 8-bit)"),
     rgb_file: Optional[UploadFile] = File(None, description="Optional RGB image"),
+    state: AppState = Depends(get_app_state),
 ):
     """Upload depth and optional RGB images.
 
@@ -226,11 +210,11 @@ async def upload(
     state.scene_type = "uploaded"
     state.height, state.width = depth_arr.shape
 
-    return _build_state_response()
+    return _build_state_response(state)
 
 
 @router.post("/process")
-async def process(req: ProcessRequest):
+async def process(req: ProcessRequest, state: AppState = Depends(get_app_state)):
     """Apply the depth processing pipeline to the current scene.
 
     Pipeline steps:
@@ -258,19 +242,19 @@ async def process(req: ProcessRequest):
     state.processed_depth = processed
     state.normals = compute_normals(processed)
 
-    return _build_state_response()
+    return _build_state_response(state)
 
 
 @router.get("/state")
-async def get_state():
+async def get_state(state: AppState = Depends(get_app_state)):
     """Return the full current state (images + mesh)."""
     if not state.has_data():
         return {"loaded": False}
-    return _build_state_response()
+    return _build_state_response(state)
 
 
 @router.post("/profile")
-async def profile(req: ProfileRequest):
+async def profile(req: ProfileRequest, state: AppState = Depends(get_app_state)):
     """Extract a cross-section profile between two points.
 
     Returns the 1D height profile, cumulative distances, and
@@ -300,7 +284,7 @@ async def profile(req: ProfileRequest):
 
 
 @router.get("/metrics")
-async def metrics():
+async def metrics(state: AppState = Depends(get_app_state)):
     """Compute global surface metrics for the current scene.
 
     Returns depth histogram, object detection results, and curvature
@@ -337,7 +321,7 @@ async def metrics():
 # ---------------------------------------------------------------------------
 
 @router.get("/export/ply")
-async def export_ply_endpoint():
+async def export_ply_endpoint(state: AppState = Depends(get_app_state)):
     """Export the current scene point cloud / mesh as PLY (ASCII).
 
     Returns a downloadable PLY file as a streaming response.
@@ -365,7 +349,7 @@ async def export_ply_endpoint():
 
 
 @router.get("/export/pcd")
-async def export_pcd_endpoint():
+async def export_pcd_endpoint(state: AppState = Depends(get_app_state)):
     """Export the current scene point cloud as PCD (ASCII).
 
     Returns a downloadable PCD file as a streaming response.
@@ -391,7 +375,7 @@ async def export_pcd_endpoint():
 
 
 @router.get("/export/obj")
-async def export_obj_endpoint():
+async def export_obj_endpoint(state: AppState = Depends(get_app_state)):
     """Export the current scene mesh as Wavefront OBJ.
 
     Returns a downloadable OBJ file as a streaming response.
@@ -421,7 +405,7 @@ async def export_obj_endpoint():
 # ---------------------------------------------------------------------------
 
 @router.post("/measure")
-async def measure(req: MeasureRequest):
+async def measure(req: MeasureRequest, state: AppState = Depends(get_app_state)):
     """Perform a measurement on the current scene.
 
     Supported measurement types:
@@ -460,8 +444,22 @@ async def measure(req: MeasureRequest):
 # Internal state builder
 # ---------------------------------------------------------------------------
 
-def _build_state_response(colormap: str = "viridis", subsample: int = 2) -> dict:
-    """Build the full JSON state response including images and mesh."""
+def _build_state_response(
+    state: AppState,
+    colormap: str = "viridis",
+    subsample: int = 2,
+) -> dict:
+    """Build the full JSON state response including images and mesh.
+
+    Parameters
+    ----------
+    state : AppState
+        The current application state (injected from the route).
+    colormap : str, default ``"viridis"``
+        Colourmap name applied to the depth map preview.
+    subsample : int, default ``2``
+        Vertex subsampling factor for the Three.js mesh.
+    """
     depth = state.processed_depth if state.processed_depth is not None else state.depth
 
     # Images as base64 PNGs

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,12 @@
+"""
+Core application primitives.
+
+This package holds cross-cutting concerns (application state, dependency
+providers) that are consumed by the API layer (``app.api``).  Keeping
+these out of the route module makes them unit-testable in isolation and
+lets FastAPI inject the state via ``Depends()``.
+"""
+
+from app.core.state import AppState, get_app_state
+
+__all__ = ["AppState", "get_app_state"]

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -1,0 +1,94 @@
+"""
+Application state for SurfaceScope.
+==========================================
+
+Holds the current RGB-D scene (RGB image, depth map, normals, processed
+depth, and scene metadata) for a single user.  Extracted from
+``app.api.routes`` so the state can be unit-tested in isolation and
+injected into FastAPI routes via ``Depends(get_app_state)``.
+
+This module intentionally has **no** FastAPI or HTTP imports so that the
+domain state stays framework-agnostic — only the provider
+``get_app_state`` is coupled to the request lifecycle.
+
+Usage
+-----
+Inside a route:
+
+    from fastapi import Depends
+    from app.core import AppState, get_app_state
+
+    @router.get("/state")
+    async def get_state(state: AppState = Depends(get_app_state)):
+        ...
+
+For tests:
+
+    from app.core import AppState
+    state = AppState()
+    state.depth = np.zeros((8, 8), dtype=np.float32)
+    assert state.has_data()
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+class AppState:
+    """Holds the current scene data in memory.
+
+    Attributes
+    ----------
+    rgb : ndarray or None
+        (H, W, 3) uint8 RGB image.
+    depth : ndarray or None
+        (H, W) float32 depth map in millimetres (raw input).
+    normals : ndarray or None
+        (H, W, 3) float32 surface normals, unit length.
+    processed_depth : ndarray or None
+        (H, W) float32 depth after the filtering pipeline.  Falls back
+        to ``depth`` when the pipeline has not run yet.
+    scene_type : str
+        Label describing the loaded scene (synthetic type or
+        ``"uploaded"``).
+    width, height : int
+        Pixel dimensions of the current scene.
+    """
+
+    def __init__(self) -> None:
+        self.rgb: Optional[np.ndarray] = None
+        self.depth: Optional[np.ndarray] = None
+        self.normals: Optional[np.ndarray] = None
+        self.processed_depth: Optional[np.ndarray] = None
+        self.scene_type: str = ""
+        self.width: int = 256
+        self.height: int = 256
+
+    def has_data(self) -> bool:
+        """Return True once a depth map has been loaded or generated."""
+        return self.depth is not None
+
+
+# ---------------------------------------------------------------------------
+# Dependency provider
+# ---------------------------------------------------------------------------
+
+# Single process-wide instance.  Kept module-level so FastAPI's
+# ``Depends(get_app_state)`` returns the same object across requests, which
+# matches the single-user demo-application semantics this project ships
+# with.  A future multi-user rework would swap this for a per-session
+# factory without touching route signatures.
+_APP_STATE = AppState()
+
+
+def get_app_state() -> AppState:
+    """FastAPI dependency that returns the process-wide ``AppState``.
+
+    Unit tests can monkey-patch ``app.core.state._APP_STATE`` or
+    override this dependency via ``app.dependency_overrides`` to inject
+    a fresh ``AppState`` per test.
+    """
+    return _APP_STATE

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -2,6 +2,14 @@
 
 ---
 
+## 2026-04-18 -- Documentation polish
+
+- Added `docs/user_guide.md`: task-oriented operator walkthrough covering launch, panels, processing knobs, cross-section profiling, export formats, troubleshooting, and REST API examples.
+- Added `docs/svg/rgbd_sensor.svg`: domain diagram showing pinhole geometry, camera lenses (IR projector / RGB / IR camera), frustum, focal length, principal point, and the pixel → 3D unprojection equations.
+- README cleanup: removed duplicated Bilateral Filter and Rq equation blocks (already covered in the Technical Approach section and in `depth_theory.md`); swapped the redundant second pipeline image for the new RGB-D sensor diagram.
+
+---
+
 ## v2.0.0 (2026-03-28) -- Complete Python Rewrite
 
 Complete rewrite of the 3D Distance Profiler as a web application with Python/FastAPI backend and Three.js frontend. Renamed to **SurfaceScope -- RGB-D Surface Profiler & Analyzer**.

--- a/docs/svg/rgbd_sensor.svg
+++ b/docs/svg/rgbd_sensor.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 420" font-family="Segoe UI, sans-serif">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f172a;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#1e293b;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="sensorGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#334155;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0f172a;stop-opacity:1"/>
+    </linearGradient>
+    <linearGradient id="surfGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b;stop-opacity:0.95"/>
+      <stop offset="100%" style="stop-color:#b45309;stop-opacity:0.95"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#38bdf8"/>
+    </marker>
+  </defs>
+
+  <rect width="820" height="420" fill="url(#bgGrad)"/>
+
+  <!-- Title -->
+  <text x="410" y="30" text-anchor="middle" fill="#e2e8f0" font-size="18" font-weight="600">
+    RGB-D Sensor Geometry — Pinhole Model &amp; Depth Acquisition
+  </text>
+  <text x="410" y="50" text-anchor="middle" fill="#94a3b8" font-size="12">
+    IR projector + RGB + depth sensors produce co-registered (u, v, Z) per pixel
+  </text>
+
+  <!-- Camera body -->
+  <rect x="80" y="150" width="160" height="110" rx="10" fill="url(#sensorGrad)" stroke="#64748b" stroke-width="1.5"/>
+  <text x="160" y="140" text-anchor="middle" fill="#cbd5e1" font-size="13" font-weight="600">RGB-D Camera</text>
+
+  <!-- Camera lenses -->
+  <circle cx="115" cy="195" r="16" fill="#1e293b" stroke="#38bdf8" stroke-width="2"/>
+  <circle cx="115" cy="195" r="8" fill="#0ea5e9"/>
+  <text x="115" y="240" text-anchor="middle" fill="#94a3b8" font-size="10">IR proj.</text>
+
+  <circle cx="160" cy="195" r="16" fill="#1e293b" stroke="#f472b6" stroke-width="2"/>
+  <circle cx="160" cy="195" r="8" fill="#ec4899"/>
+  <text x="160" y="240" text-anchor="middle" fill="#94a3b8" font-size="10">RGB</text>
+
+  <circle cx="205" cy="195" r="16" fill="#1e293b" stroke="#34d399" stroke-width="2"/>
+  <circle cx="205" cy="195" r="8" fill="#10b981"/>
+  <text x="205" y="240" text-anchor="middle" fill="#94a3b8" font-size="10">IR cam</text>
+
+  <!-- Optical axis -->
+  <line x1="240" y1="205" x2="560" y2="205" stroke="#475569" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="400" y="200" text-anchor="middle" fill="#64748b" font-size="10">optical axis (Z)</text>
+
+  <!-- Frustum -->
+  <polygon points="240,205 560,100 560,310" fill="rgba(56,189,248,0.08)" stroke="#38bdf8" stroke-width="1" stroke-dasharray="3 3"/>
+
+  <!-- Principal point cx, cy + focal length -->
+  <line x1="240" y1="205" x2="240" y2="130" stroke="#fbbf24" stroke-width="1"/>
+  <text x="255" y="125" fill="#fbbf24" font-size="11">(cx, cy)</text>
+  <text x="290" y="220" fill="#fbbf24" font-size="11">f (focal length)</text>
+
+  <!-- Surface -->
+  <path d="M 560,100 Q 620,180 580,250 T 560,310 L 660,310 Q 700,240 690,180 T 660,100 Z"
+        fill="url(#surfGrad)" stroke="#f59e0b" stroke-width="1.5" opacity="0.9"/>
+  <text x="615" y="370" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="600">Scene surface</text>
+  <text x="615" y="388" text-anchor="middle" fill="#94a3b8" font-size="10">z = f(x, y)</text>
+
+  <!-- Ray to 3D point P -->
+  <circle cx="620" cy="170" r="5" fill="#fbbf24" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="632" y="165" fill="#e2e8f0" font-size="11" font-weight="600">P = (X, Y, Z)</text>
+  <line x1="240" y1="205" x2="620" y2="170" stroke="#38bdf8" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Pixel (u, v) label near lens plane -->
+  <circle cx="340" cy="172" r="3" fill="#38bdf8"/>
+  <text x="315" y="165" fill="#38bdf8" font-size="11">pixel (u, v)</text>
+
+  <!-- Equations panel -->
+  <rect x="50" y="295" width="360" height="100" rx="8" fill="#0b1220" stroke="#334155" stroke-width="1"/>
+  <text x="65" y="315" fill="#e2e8f0" font-size="12" font-weight="600">Pinhole unprojection (pixel → 3D):</text>
+  <text x="65" y="338" fill="#cbd5e1" font-size="12" font-family="monospace">X = (u − cx) · Z / fx</text>
+  <text x="65" y="356" fill="#cbd5e1" font-size="12" font-family="monospace">Y = (v − cy) · Z / fy</text>
+  <text x="65" y="380" fill="#94a3b8" font-size="10">fx, fy = focal lengths (px);  cx, cy = principal point;  Z = depth</text>
+
+  <!-- Depth sample legend -->
+  <rect x="430" y="335" width="370" height="60" rx="8" fill="#0b1220" stroke="#334155" stroke-width="1"/>
+  <text x="445" y="355" fill="#e2e8f0" font-size="11" font-weight="600">Per-pixel output:</text>
+  <rect x="445" y="365" width="14" height="14" fill="#ec4899"/>
+  <text x="465" y="377" fill="#cbd5e1" font-size="11">RGB(u,v)</text>
+  <rect x="545" y="365" width="14" height="14" fill="#10b981"/>
+  <text x="565" y="377" fill="#cbd5e1" font-size="11">Depth Z(u,v) [mm]</text>
+  <rect x="690" y="365" width="14" height="14" fill="#38bdf8"/>
+  <text x="710" y="377" fill="#cbd5e1" font-size="11">Normal n̂(u,v)</text>
+</svg>

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,137 @@
+# User Guide — SurfaceScope (RGB-D Surface Profiler & Analyzer)
+
+A task-oriented guide for operators. For the theory behind each step, see [depth_theory.md](depth_theory.md); for the system layout, see [architecture.md](architecture.md).
+
+---
+
+## 1. Launching the App
+
+```bash
+cd "d:/_Repos/_SCIENCE/FASL_3D_Distance_Profiler"
+python -m venv .venv
+source .venv/Scripts/activate   # Windows Git Bash
+pip install -r requirements.txt
+python run_app.py
+```
+
+The app opens automatically at [http://localhost:8009](http://localhost:8009). The server is single-user and holds its state in RAM — restart clears everything.
+
+---
+
+## 2. Panel Overview
+
+SurfaceScope uses a 3-panel layout:
+
+| Panel           | Purpose                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| Left (controls) | Scene selection, upload, processing parameters, export buttons          |
+| Centre (2D)     | RGB / depth colourmap / normal map canvases + cross-section tool        |
+| Right (3D)      | Three.js interactive surface viewer with mesh / wireframe / point modes |
+
+Press the `?` button in the header for the in-app keyboard/mouse reference.
+
+---
+
+## 3. Typical Workflow
+
+### 3.1 Load data
+
+Pick one of the two sources:
+
+- **Generate synthetic scene** — choose from `gaussian_hills`, `terrain`, `object_on_table`, `conveyor_belt`, `wave_surface`. Adjust `width`, `height`, and `seed` for reproducibility. Good for demos and regression.
+- **Upload depth + RGB** — supports 8-bit and 16-bit PNG. The depth image is treated as raw depth in millimetres (16-bit) or normalised (8-bit). The RGB image is optional — a neutral grey texture is applied if omitted.
+
+Once loaded, the 2D panel shows RGB, depth (with the selected colourmap), and per-pixel surface normals.
+
+### 3.2 Process the depth map
+
+Under **Processing**, tune the pipeline:
+
+- `bilateral_sigma_spatial` (σ_s) — spatial kernel radius in pixels. Larger = more smoothing. Typical: 3–7.
+- `bilateral_sigma_range` (σ_r) — depth-similarity kernel in millimetres. Larger = more smoothing across steps. Typical: 5–30.
+- `fill_hole_size` — maximum contiguous invalid-pixel region to fill via nearest-neighbour interpolation. Use 0 to disable.
+
+Click **Process** — the depth map, normals, and 3D mesh update in place.
+
+### 3.3 Inspect in 3D
+
+Drag on the 3D canvas to orbit (left button), pan (right button), and wheel to zoom. Use the toggles to switch between:
+
+- **Mesh** — shaded Phong surface with per-vertex RGB colours.
+- **Wireframe** — triangle edges only. Useful to inspect sampling density.
+- **Points** — vertex cloud. Good for visual noise assessment.
+
+### 3.4 Extract a cross-section profile
+
+Click two points on the depth canvas. The backend extracts a 1D height profile via bilinear interpolation along the line and returns:
+
+- distances / heights arrays (rendered as a profile chart)
+- ISO 4287 roughness metrics: **Ra** (mean deviation), **Rq** (RMS), **Rz** (peak-to-valley), **Rsk** (skewness), **Rku** (kurtosis)
+
+Ra and Rq characterise average roughness; Rz captures the worst feature; Rsk and Rku describe asymmetry and peakedness of the height distribution.
+
+### 3.5 Metrics & object detection
+
+The **Metrics** panel shows the full-frame depth histogram, Gaussian and mean curvature statistics, and the list of detected raised objects (connected-component labelling after depth thresholding). Each object entry includes bounding box, centroid, pixel count, and mean height.
+
+### 3.6 Export
+
+From the export section:
+
+| Format | Use case                                     | Tool                     |
+|--------|----------------------------------------------|--------------------------|
+| PLY    | Point cloud + mesh + per-vertex colour       | MeshLab, CloudCompare    |
+| PCD    | Point cloud only (no topology)               | PCL, Open3D              |
+| OBJ    | Mesh with triangular faces                   | Blender, MeshLab         |
+
+Each file is streamed as an ASCII download — no temporary files are written to disk.
+
+---
+
+## 4. Troubleshooting
+
+| Symptom                              | Likely cause                                    | Fix                                                             |
+|--------------------------------------|-------------------------------------------------|-----------------------------------------------------------------|
+| Port 8009 already in use             | Another SCIAN/FASL app is running               | Stop the other app or change the port in `run_app.py`           |
+| 3D panel empty after load            | Depth map all-zero (bad upload)                 | Verify depth PNG encodes non-zero pixels                        |
+| Bilateral filter feels too slow      | Large σ_s (kernel half-size ∝ σ_s)              | Reduce σ_s or subsample resolution                              |
+| Cross-section jagged                 | Hole filling disabled + invalid pixels on path  | Increase `fill_hole_size`                                       |
+| Object detection misses raised parts | Threshold too close to background               | Adjust depth threshold under Metrics                            |
+| Exported PLY opens empty in MeshLab  | File saved with ASCII header but binary payload | Re-export — SurfaceScope always writes ASCII; retry the download|
+
+---
+
+## 5. Programmatic Use (REST API)
+
+Every UI action corresponds to a REST endpoint. Example using `curl`:
+
+```bash
+# Generate a synthetic scene
+curl -X POST http://localhost:8009/api/generate \
+     -H "Content-Type: application/json" \
+     -d '{"scene_type": "gaussian_hills", "width": 256, "height": 256, "seed": 42}'
+
+# Apply the processing pipeline
+curl -X POST http://localhost:8009/api/process \
+     -H "Content-Type: application/json" \
+     -d '{"bilateral_sigma_spatial": 5, "bilateral_sigma_range": 20, "fill_hole_size": 3}'
+
+# Extract a profile and compute roughness
+curl -X POST http://localhost:8009/api/profile \
+     -H "Content-Type: application/json" \
+     -d '{"start_x": 32, "start_y": 64, "end_x": 224, "end_y": 192, "num_samples": 200}'
+
+# Download the surface as PLY
+curl -O -J http://localhost:8009/api/export/ply
+```
+
+See [architecture.md](architecture.md) for the full endpoint table and request/response shapes.
+
+---
+
+## 6. Where to go next
+
+- Theory reference: [depth_theory.md](depth_theory.md)
+- System architecture: [architecture.md](architecture.md)
+- Version log: [development_history.md](development_history.md)
+- Papers & standards: [references.md](references.md)


### PR DESCRIPTION
Closes #16

## Summary
- Extracted `AppState` from `app/api/routes.py` into `app/core/state.py` so the state is framework-agnostic and unit-testable in isolation.
- New `app/core/__init__.py` re-exports `AppState` and `get_app_state` for ergonomic imports.
- Every route in `routes.py` now receives the state via FastAPI `Depends(get_app_state)` instead of referencing a module-level global.
- `_build_state_response` now takes the state as an explicit argument.

## Why
Prerequisite for:
- Session save/load (#15)
- Future per-session state injection in tests (`app.dependency_overrides`).

## Test plan
- [x] `pytest tests/ -q` — 90 passed, 1 warning (pre-existing `RuntimeWarning: invalid value encountered in divide` in `bilateral_filter_depth`)
- [x] FastAPI smoke test via `TestClient`: `GET /api/state` returns `{"loaded": false}`, `GET /api/scene_types` returns 5 scene types.
- [x] No imports of `app.api.routes.state` or `app.api.routes.AppState` exist outside the module.

## Risk
Mechanical refactor, no behavior change. Single-user singleton semantics preserved via module-level `_APP_STATE` in the new module.

Generated with [Claude Code](https://claude.com/claude-code)